### PR TITLE
fix: auto-fallback to gist adapter on private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ flowchart TD
 
     S --> T{Output}
     T -->|Default| U["Save to ~/Downloads"]
-    T -->|--markdown| V[Commit to PR branch]
-    V --> W[Markdown table for PR]
+    T -->|--markdown| V{Upload}
+    V -->|Public repo| W["Commit to .pre-post/"]
+    V -->|Private repo| X["GitHub Gist (auto)"]
+    V -->|--upload-url| Y["Custom storage"]
+    W --> Z[Markdown table for PR]
+    X --> Z
+    Y --> Z
 
     style A fill:#4f46e5,color:#fff
     style L fill:#2563eb,color:#fff
@@ -68,10 +73,9 @@ flowchart TD
 ## Prerequisites
 
 - **Node.js** 18+
-- **Chromium** (auto-installed on first run via Playwright)
+- **Chromium** — install once via Playwright:
 
 ```bash
-# Install Chromium browser for Playwright (one-time setup)
 npx playwright install chromium
 ```
 
@@ -115,7 +119,7 @@ Detect affected routes from git changes:
 
 ```bash
 pre-post detect                        # Auto-detect framework
-pre-post detect --framework nextjs     # Force framework
+pre-post detect --framework nextjs-app  # Force framework
 ```
 
 Outputs JSON with route paths, confidence levels, and source files.
@@ -177,13 +181,13 @@ Save to a custom location:
 pre-post url1 url2 --output ./screenshots
 ```
 
-Override the default upload method:
+Upload to a custom image storage service:
 
 ```bash
-pre-post url1 url2 --upload-url https://uploads.example.com
+pre-post url1 url2 --markdown --upload-url https://my-s3-bucket.amazonaws.com
 ```
 
-By default, screenshots are committed directly to the PR branch (under `.pre-post/`) and served via `raw.githubusercontent.com`. Use `--upload-url` to override with a custom storage service. Screenshots auto-append to the PR body, newest on top.
+By default, `--markdown` commits screenshots to the PR branch (under `.pre-post/`) and serves them via `raw.githubusercontent.com`. For **private repos**, this is detected automatically and screenshots upload as GitHub Gists instead — no configuration needed. Use `--upload-url` to point at your own storage instead. It auto-detects the protocol for 0x0.st, Vercel Blob, and any generic PUT endpoint (like S3). Screenshots auto-append to the PR body, newest on top.
 
 ## Route Detection
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -222,17 +222,22 @@ npx pre-post compare --before-base URL --after-base URL
 
 ## Image Upload
 
-Screenshots are committed to `.pre-post/` on the current PR branch and served via `raw.githubusercontent.com`. This is the default — no external services needed.
+Screenshots are committed to `.pre-post/` on the current PR branch and served via
+`raw.githubusercontent.com`. This is the default for **public repos**.
+
+**Private repos:** Automatically detected via `gh api`. Falls back to the **gist**
+adapter — screenshots are uploaded as GitHub Gists with permanent URLs. No extra
+configuration needed (uses existing `gh` authentication).
 
 ```bash
-# Default (git-native — commits to PR branch)
+# Default (git-native — commits to PR branch, public repos)
 ./scripts/upload-and-copy.sh before.png after.png --markdown
 
-# Fallback: 0x0.st (no signup needed, 365-day expiry)
-IMAGE_ADAPTER=0x0st ./scripts/upload-and-copy.sh before.png after.png --markdown
+# Automatic: private repos auto-fallback to gist (no manual flag needed)
 
-# GitHub Gist
+# Explicit overrides:
 IMAGE_ADAPTER=gist ./scripts/upload-and-copy.sh before.png after.png --markdown
+IMAGE_ADAPTER=0x0st ./scripts/upload-and-copy.sh before.png after.png --markdown
 ```
 
 ## Error Reference
@@ -244,3 +249,4 @@ IMAGE_ADAPTER=gist ./scripts/upload-and-copy.sh before.png after.png --markdown
 | 401/403 on production URL | See pre-flight section above |
 | Element not found | Verify selector exists on page |
 | No changed files detected | Specify routes manually with `--routes` |
+| Private repo, broken images | Auto-detected; falls back to gist adapter |


### PR DESCRIPTION
## Summary

- **Private repo detection**: `git-native` upload generates `raw.githubusercontent.com` URLs that 404 on private repos. Now auto-detects visibility via `gh api` and silently falls back to the **gist** adapter — no broken images, no manual re-run
- **Bash + TypeScript paths**: Both `upload-and-copy.sh` and `src/upload.ts` get the same detection logic, so the fix works from CLI and skill
- **README audit fixes**: Corrected `--framework nextjs` → `nextjs-app`, removed contradictory Chromium "auto-install" claim, added `--markdown` to `--upload-url` example (required flag), updated mermaid diagram to show all three upload paths

## Files changed

| File | What |
|------|------|
| `skill/scripts/upload-and-copy.sh` | Visibility check before adapter invocation; swap to gist if private |
| `src/upload.ts` | `checkRepoVisibility()`, `uploadToGist()`, fallback in `uploadBeforeAfter()` |
| `tests/integration/upload.test.ts` | 9 new tests for private repo fallback + fixed 2 pre-existing broken tests (ESM mock) |
| `skill/SKILL.md` | Document private repo behavior, add error reference row |
| `README.md` | Upload section rewrite, mermaid diagram update, framework flag fix, Chromium install fix |

## Test plan

- [x] `npx vitest run tests/integration/upload.test.ts` — 23 pass, 1 skipped (real upload)
- [ ] Smoke test on a private repo → confirm gist fallback with info message
- [ ] Verify `gh api repos/juangadm/pre-post --jq '.visibility'` returns `public` (no false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)