### PR TITLE
Add animated GIF capture support with --video flag

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,3 +28,271 @@
 
 - [ ] Mobile layout check — stacked or scaled workspace view
 - [ ] Consider reduced-motion: skip animations, show static workspace + PR side by side
+
+---
+
+## Video/GIF Support — Spec
+
+### 1. Feature Summary
+
+`--video` flag on the `pre-post` CLI captures animated GIFs of web pages.
+GIFs show page-load animations, CSS transitions, and layout changes.
+They render inline in GitHub PR comments alongside static screenshots.
+
+`--video` is opt-in. Static PNG screenshots remain the default behavior.
+
+### 2. Encoding Pipeline
+
+Sequential Playwright JPEG screenshots encoded into animated GIF via gifenc.
+Single codepath. No FFmpeg. No external dependencies beyond Playwright + gifenc
+(both already in `package.json`).
+
+**Step-by-step:**
+
+```
+1. getBrowser()           → get/create shared Playwright Browser instance
+2. browser.newPage()      → new page with viewport at DPR 1 (no animation-killing CSS)
+3. page.goto(url)         → waitUntil: 'networkidle'
+4. page.evaluate()        → document.fonts.ready
+5. page.waitForTimeout()  → --delay ms (default 0)
+6. [optional] locator.scrollIntoViewIfNeeded() → if --selector provided
+7. LOOP (totalFrames = duration × fps):
+   a. page.screenshot({ type: 'jpeg', quality: 80 })  → JPEG Buffer
+   b. page.waitForTimeout(frameInterval)               → pace capture
+8. page.close()
+9. For each JPEG Buffer:
+   a. Decode to RGBA via hidden canvas page (base64 data URL → drawImage → getImageData)
+   b. quantize(rgba, 256, { format: 'rgba4444' })      → 256-color palette
+   c. applyPalette(rgba, palette, 'rgba4444')           → indexed pixel array
+   d. encoder.writeFrame(indexed, width, height, { palette, delay, repeat: 0 })
+10. encoder.finish()
+11. Buffer.from(encoder.bytes())                        → GIF Buffer
+12. Size check: if > 10 MB → error
+13. uploadGitNative() → commit to .pre-post/, push, return blob+SHA URL
+```
+
+**JPEG decode detail (step 9a):**
+Reuse the shared Browser to open a utility page with `<canvas id="c">`.
+Pass each JPEG as `data:image/jpeg;base64,...` into `page.evaluate()`,
+draw onto canvas at target dimensions, call `getImageData()`, return
+pixel array. This avoids adding `sharp` or `pngjs` as dependencies.
+The utility page is created once and reused across all frames.
+Closed in a `finally` block after encoding completes.
+
+**gifenc import detail:**
+gifenc ships as CJS. Use `createRequire(import.meta.url)` for ESM compat:
+```typescript
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { GIFEncoder, quantize, applyPalette } = require('gifenc');
+```
+
+### 3. Capture Settings
+
+| Setting | Default | Max | Rationale |
+|---------|---------|-----|-----------|
+| FPS | 5 | 10 | Each JPEG screenshot at 1280x800 DPR 1 takes ~100-200ms. 5 FPS is reliably achievable. |
+| Duration | 3s | 10s | 3s covers page load + initial CSS transitions. 10s cap → 50 frames max. |
+| DPR | 1 | 1 | Fixed at 1. DPR 2 quadruples pixel count; 256-color GIF cannot reproduce the detail. |
+| Viewport | Inherited | — | Uses existing viewport flags (--mobile, --tablet, --size, default desktop). |
+
+**Frame interval calculation:**
+```typescript
+const frameInterval = Math.round(1000 / fps);  // 200ms at 5 FPS
+const totalFrames = Math.ceil(duration * fps);  // 15 at 3s × 5fps
+```
+The actual FPS will be slightly lower than target because `page.screenshot()` takes
+~100-200ms on top of the interval. At 5 FPS target, real-world is ~3-4 FPS.
+Animations continue playing during screenshots — frames are temporally correct.
+
+### 4. Viewport Dimensions for GIF
+
+GIFs capture at the full viewport size. No downscaling.
+
+| Viewport preset | GIF dimensions | Est. file size (15 frames) | Est. file size (50 frames) |
+|----------------|---------------|---------------------------|---------------------------|
+| `desktop` | 1280×800 | 1.5–3.5 MB | 4–8 MB |
+| `mobile` | 375×667 | 0.2–0.7 MB | 0.5–2 MB |
+| `tablet` | 768×1024 | 0.8–2 MB | 2–5 MB |
+
+**Mobile height is 667px, not 812px.** The existing `mobile` preset uses 812px
+(full iPhone viewport). For GIF mode, the height is capped at 667px (above-the-fold)
+to avoid a comically tall image in PR comments. This is done in `captureVideo()` by
+overriding the viewport height when the mobile preset is detected.
+
+### 5. Size Limit
+
+**10 MB hard limit.** Enforced in `uploadGitNative()` before writing the file.
+Error message: `"GIF is ${size} MB (limit: 10 MB). Reduce --duration or --fps."`
+
+No automatic downscaling. The user controls output size via `--duration` and `--fps`.
+
+### 6. Upload
+
+Uses the existing `uploadGitNative()` flow — identical to PNG screenshots:
+1. Write GIF to `.pre-post/` directory in repo root
+2. `git add -f` the file
+3. `git commit -m "chore: add pre/post screenshots"`
+4. `git push origin HEAD`
+5. Construct blob URL: `https://github.com/{owner}/{repo}/blob/{sha}/.pre-post/{filename}?raw=true`
+
+GIF content type is handled automatically — GitHub serves `?raw=true` blob URLs
+with the correct MIME type based on file extension.
+
+### 7. CLI Interface
+
+New `parseArgs` options in `src/bin/cli.ts`:
+
+```typescript
+video: { type: 'boolean' },
+duration: { type: 'string' },
+fps: { type: 'string' },
+delay: { type: 'string' },
+```
+
+Help text addition:
+```
+VIDEO OPTIONS:
+      --video                Capture animated GIF instead of static screenshot
+      --duration <seconds>   Recording duration (default: 3, max: 10)
+      --fps <n>              Target frames per second (default: 5, max: 10)
+      --delay <ms>           Wait after page load before recording (default: 0)
+```
+
+**Flag validation:**
+- `--video` + `--full` → hard error: `"--full (fullPage) is not supported with --video"`
+- `--duration` > 10 → hard error: `"Max duration is 10 seconds"`
+- `--fps` > 10 → hard error: `"Max FPS is 10"`
+- `--duration` or `--fps` or `--delay` without `--video` → ignored (no error)
+
+**Integration points:**
+
+`runDefault()` — When `--video` is set:
+- Replace `captureBeforeAfter()` calls with `captureVideo()` for both before and after URLs
+- Generate `.gif` filenames instead of `.png`
+- Upload GIFs via same `uploadAndOutputMarkdown()` path
+
+`runCompare()` — When `--video` is set:
+- Replace `captureScreenshot()` calls with `captureVideo()` for each route
+- Works with `--responsive` (desktop GIF + mobile GIF per route)
+
+`runFull()` — Passes `--video` through to `runCompare()`.
+
+**CLI examples:**
+```bash
+pre-post https://old.com https://new.com --video
+pre-post https://old.com https://new.com --video --duration 5 --delay 500
+pre-post compare --before-base prod.com --after-base localhost:3000 --video
+pre-post compare --before-base prod.com --after-base localhost:3000 --video --responsive
+pre-post compare --before-base prod.com --after-base localhost:3000 --video --mobile --duration 5
+pre-post run --before-base prod.com --after-base localhost:3000 --video
+```
+
+### 8. File Changes
+
+**`src/browser.ts`** — Add exported function:
+```typescript
+export async function getBrowser(): Promise<Browser> {
+  if (!browser) {
+    browser = await launchBrowser();
+  }
+  return browser;
+}
+```
+This gives `video.ts` access to the Browser instance without going through
+`getPage()` which injects animation-killing CSS.
+
+**`src/types.ts`** — Add types at the end of the file:
+```typescript
+export interface VideoOptions {
+  viewport: ViewportSize;
+  duration?: number;    // seconds, default 3, max 10
+  fps?: number;         // default 5, max 10
+  delay?: number;       // ms after load, default 0
+  selector?: string;
+  fullPage?: boolean;   // always false for video — validated in CLI
+}
+
+export interface VideoResult {
+  gif: Buffer;
+  format: 'gif';
+  viewport: ViewportSize;
+  url: string;
+  duration: number;
+  frameCount: number;
+  selector?: string;
+}
+```
+
+**`src/filename.ts`** — Change line 96:
+```typescript
+// Before:
+return `${pageName}${elementPart}${suffixPart}-${timestamp}.png`;
+
+// After:
+const ext = options.format === 'gif' ? 'gif' : 'png';
+return `${pageName}${elementPart}${suffixPart}-${timestamp}.${ext}`;
+```
+Add `format?: 'png' | 'gif'` to `FilenameOptions` interface.
+
+**`src/video.ts`** — Rewrite the existing draft. Two exported functions:
+
+`captureGif(page: Page, url: string, options: VideoOptions): Promise<VideoResult>`
+- Takes an existing Playwright Page (caller manages lifecycle)
+- Navigates, waits, captures frames, encodes GIF
+- Returns VideoResult with GIF Buffer
+
+`captureVideo(url: string, options: VideoOptions): Promise<VideoResult>`
+- High-level entry point
+- Calls `getBrowser()`, creates a new page at DPR 1, calls `captureGif()`
+- Wraps everything in try/finally to close page + decoder page on error/success
+- Includes early-stop logic: if 3 consecutive frames are identical (byte-level
+  Buffer.equals comparison on JPEG data), stop capture and log
+  `"Animation settled after ${i} frames"`
+
+**`src/upload.ts`** — Add size guard at top of `uploadGitNative()`:
+```typescript
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+if (image.length > MAX_FILE_SIZE) {
+  const sizeMB = (image.length / 1024 / 1024).toFixed(1);
+  throw new Error(
+    `File is ${sizeMB} MB (limit: 10 MB). Reduce --duration or --fps.`
+  );
+}
+```
+
+**`src/bin/cli.ts`** — Add flags, validation, and wiring as described in section 7.
+
+**`src/index.ts`** — Add exports:
+```typescript
+export { captureVideo } from './video.js';
+export type { VideoOptions, VideoResult } from './types.js';
+```
+
+### 9. Edge Cases
+
+| Scenario | Detection | Response |
+|----------|-----------|----------|
+| `--video` + `--full` | CLI flag check | Hard error before any browser work |
+| Selector not found | `locator.count() === 0` | Hard error before recording |
+| Page returns 4xx/5xx | Check `page.goto()` response status | Log warning, continue (page may still have content) |
+| Infinite animation | 3+ identical JPEG frames | Stop early, log "animation settled after N frames" |
+| GIF > 10 MB | Check `Buffer.length` after encoding | Hard error with actionable message |
+| Memory pressure | 50 frames × 1280×800×4 = ~200 MB | Acceptable. Max frames capped at 50. |
+| Decoder page leak | Page not closed on error | `try/finally` in `captureVideo()` closes page + decoder |
+| Browser launch failure | Same as screenshot mode | Same error handling — fallback chain in `launchBrowser()` |
+
+### 10. Implementation Order
+
+```
+1. src/browser.ts      → getBrowser() export (3 lines)
+2. src/types.ts         → VideoOptions, VideoResult types
+3. src/filename.ts      → format parameter on FilenameOptions + generateFilename()
+4. src/video.ts         → full rewrite: captureGif(), captureVideo(), JPEG→RGBA decode
+5. src/upload.ts        → 10 MB size guard in uploadGitNative()
+6. src/bin/cli.ts       → --video, --duration, --fps, --delay flags + wiring
+7. src/index.ts         → exports
+8. Build                → tsc -p tsconfig.pkg.json (verify no type errors)
+9. Test                 → capture real GIF against a live URL, check file size, check GitHub render
+10. Commit + push
+```

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:integration": "vitest run tests/integration"
   },
   "dependencies": {
+    "gifenc": "^1.0.3",
     "playwright": "^1.50.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      gifenc:
+        specifier: ^1.0.3
+        version: 1.0.3
       playwright:
         specifier: ^1.50.0
         version: 1.58.0
@@ -952,6 +955,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gifenc@1.0.3:
+    resolution: {integrity: sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2335,6 +2341,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gifenc@1.0.3: {}
 
   glob-parent@5.1.2:
     dependencies:

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -7,11 +7,9 @@ import { BeforeAndAfter, generateFilename } from '../index.js';
 import { ViewportConfig, VIEWPORT_PRESETS } from '../types.js';
 import { closeBrowser } from '../browser.js';
 import { captureScreenshot, captureResponsive } from '../capture.js';
-import { captureVideo } from '../video.js';
 import { uploadBeforeAfter } from '../upload.js';
 import { copyToClipboard } from '../clipboard.js';
 import { detectRoutes, getChangedFiles, detectFramework } from '../routes.js';
-import { resolveViewport } from '../viewport.js';
 
 // Determine subcommand
 const subcommand = process.argv[2];
@@ -44,11 +42,6 @@ const { values, positionals } = parseArgs({
     framework: { type: 'string' },
     'before-base': { type: 'string' },
     'after-base': { type: 'string' },
-    // Video/GIF options
-    video: { type: 'boolean' },
-    duration: { type: 'string' },
-    fps: { type: 'string' },
-    delay: { type: 'string' },
   },
 });
 
@@ -90,12 +83,6 @@ COMPARE OPTIONS:
       --before-base <url>    Base URL for "before" state (production)
       --after-base <url>     Base URL for "after" state (localhost)
 
-VIDEO OPTIONS:
-      --video                Capture animated GIF instead of static screenshot
-      --duration <seconds>   Recording duration (default: 3, max: 10)
-      --fps <n>              Target frames per second (default: 5, max: 10)
-      --delay <ms>           Wait after page load before recording (default: 0)
-
 OUTPUT OPTIONS:
   -o, --output <dir>         Output directory (default: ~/Downloads)
       --markdown             Upload images & output markdown table
@@ -123,13 +110,6 @@ EXAMPLES:
   # Responsive capture (desktop + mobile)
   pre-post compare --before-base url1 --after-base url2 --responsive
 
-  # Capture animated GIFs instead of static screenshots
-  pre-post google.com facebook.com --video
-  pre-post google.com facebook.com --video --duration 5 --fps 8
-
-  # GIF capture with compare mode
-  pre-post compare --before-base url1 --after-base url2 --video --delay 500
-
   # Use existing images (auto-detected)
   pre-post before.png after.png --markdown
 `);
@@ -150,30 +130,6 @@ function normalizeUrl(url: string): string {
     return `http://${url}`;
   }
   return `https://${url}`;
-}
-
-/**
- * Validate --video flag combinations and parse video-related options.
- */
-function validateVideoFlags(): void {
-  if (!values.video) return;
-
-  if (values.full) {
-    console.error('--full (fullPage) is not supported with --video');
-    process.exit(1);
-  }
-
-  const duration = values.duration ? parseFloat(values.duration) : 3;
-  if (duration <= 0 || duration > 10) {
-    console.error('Duration must be between 0.1 and 10 seconds');
-    process.exit(1);
-  }
-
-  const fps = values.fps ? parseInt(values.fps) : 5;
-  if (fps < 1 || fps > 10) {
-    console.error('FPS must be between 1 and 10');
-    process.exit(1);
-  }
 }
 
 function resolveViewportFlag(): ViewportConfig {
@@ -236,99 +192,48 @@ async function runCompare(): Promise<void> {
 
   const timestamp = new Date();
 
-  const isVideo = values.video ?? false;
-  const ext = isVideo ? 'gif' : 'png';
-  const captureType = isVideo ? 'GIF' : 'screenshot';
-
   try {
     for (const route of routeList) {
       const beforeUrl = normalizeUrl(beforeBase.replace(/\/$/, '') + route);
       const afterUrl = normalizeUrl(afterBase.replace(/\/$/, '') + route);
-      const routeSlug = route === '/' ? 'home' : route.replace(/^\//, '').replace(/\//g, '-');
 
       if (responsive) {
         // Capture desktop + mobile for each route
         for (const preset of ['desktop', 'mobile'] as const) {
           const vp = VIEWPORT_PRESETS[preset];
-          console.log(`Capturing ${captureType} ${route} @ ${preset} (${vp.width}x${vp.height})...`);
 
-          if (isVideo) {
-            const videoOpts = {
-              viewport: vp,
-              duration: values.duration ? parseFloat(values.duration) : undefined,
-              fps: values.fps ? parseInt(values.fps) : undefined,
-              delay: values.delay ? parseInt(values.delay) : undefined,
-              selector: values.selector,
-            };
+          console.log(`Capturing ${route} @ ${preset} (${vp.width}x${vp.height})...`);
 
-            const beforeResult = await captureVideo(beforeUrl, videoOpts);
-            const afterResult = await captureVideo(afterUrl, videoOpts);
+          const beforeResult = await captureScreenshot({ url: beforeUrl, viewport: preset });
+          const afterResult = await captureScreenshot({ url: afterUrl, viewport: preset });
 
-            const beforeFilename = `${routeSlug}-${preset}-before-${formatTimestamp(timestamp)}.${ext}`;
-            const afterFilename = `${routeSlug}-${preset}-after-${formatTimestamp(timestamp)}.${ext}`;
-
-            fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.gif);
-            fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.gif);
-            console.log(`  Saved: ${beforeFilename} (${beforeResult.frameCount}f), ${afterFilename} (${afterResult.frameCount}f)`);
-          } else {
-            const beforeResult = await captureScreenshot({
-              url: beforeUrl,
-              viewport: preset,
-              fullPage: values.full,
-              selector: values.selector,
-            });
-            const afterResult = await captureScreenshot({
-              url: afterUrl,
-              viewport: preset,
-              fullPage: values.full,
-              selector: values.selector,
-            });
-
-            const beforeFilename = `${routeSlug}-${preset}-before-${formatTimestamp(timestamp)}.${ext}`;
-            const afterFilename = `${routeSlug}-${preset}-after-${formatTimestamp(timestamp)}.${ext}`;
-
-            fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.image);
-            fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.image);
-            console.log(`  Saved: ${beforeFilename}, ${afterFilename}`);
-          }
-        }
-      } else {
-        console.log(`Capturing ${captureType} ${route}...`);
-
-        if (isVideo) {
-          const resolvedVp = resolveViewport(viewport);
-          const videoOpts = {
-            viewport: resolvedVp,
-            duration: values.duration ? parseFloat(values.duration) : undefined,
-            fps: values.fps ? parseInt(values.fps) : undefined,
-            delay: values.delay ? parseInt(values.delay) : undefined,
-            selector: values.selector,
-          };
-
-          const beforeResult = await captureVideo(beforeUrl, videoOpts);
-          const afterResult = await captureVideo(afterUrl, videoOpts);
-
-          const beforeFilename = `${routeSlug}-before-${formatTimestamp(timestamp)}.${ext}`;
-          const afterFilename = `${routeSlug}-after-${formatTimestamp(timestamp)}.${ext}`;
-
-          fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.gif);
-          fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.gif);
-          console.log(`  Saved: ${beforeFilename} (${beforeResult.frameCount}f), ${afterFilename} (${afterResult.frameCount}f)`);
-        } else {
-          const beforeResult = await captureScreenshot({ url: beforeUrl, viewport, fullPage: values.full });
-          const afterResult = await captureScreenshot({ url: afterUrl, viewport, fullPage: values.full });
-
-          const beforeFilename = `${routeSlug}-before-${formatTimestamp(timestamp)}.${ext}`;
-          const afterFilename = `${routeSlug}-after-${formatTimestamp(timestamp)}.${ext}`;
+          const routeSlug = route === '/' ? 'home' : route.replace(/^\//, '').replace(/\//g, '-');
+          const beforeFilename = `${routeSlug}-${preset}-before-${formatTimestamp(timestamp)}.png`;
+          const afterFilename = `${routeSlug}-${preset}-after-${formatTimestamp(timestamp)}.png`;
 
           fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.image);
           fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.image);
+
           console.log(`  Saved: ${beforeFilename}, ${afterFilename}`);
         }
+      } else {
+        console.log(`Capturing ${route}...`);
+
+        const beforeResult = await captureScreenshot({ url: beforeUrl, viewport, fullPage: values.full });
+        const afterResult = await captureScreenshot({ url: afterUrl, viewport, fullPage: values.full });
+
+        const routeSlug = route === '/' ? 'home' : route.replace(/^\//, '').replace(/\//g, '-');
+        const beforeFilename = `${routeSlug}-before-${formatTimestamp(timestamp)}.png`;
+        const afterFilename = `${routeSlug}-after-${formatTimestamp(timestamp)}.png`;
+
+        fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.image);
+        fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.image);
+
+        console.log(`  Saved: ${beforeFilename}, ${afterFilename}`);
       }
     }
 
-    console.log(`\nAll ${captureType}s saved to: ${outputDir}`);
+    console.log(`\nAll screenshots saved to: ${outputDir}`);
   } finally {
     await closeBrowser();
   }
@@ -401,12 +306,7 @@ async function runDefault(): Promise<void> {
       });
 
       if (values.markdown) {
-        await uploadAndOutputMarkdown(
-          result.beforeImage,
-          result.afterImage,
-          path.basename(first),
-          path.basename(second),
-        );
+        console.log(result.markdown);
       } else {
         console.log(`Before: ${first}`);
         console.log(`After:  ${second}`);
@@ -433,72 +333,65 @@ async function runDefault(): Promise<void> {
     const outputDir = values.output || path.join(process.env.HOME || '~', 'Downloads');
     fs.mkdirSync(outputDir, { recursive: true });
 
-    const isVideo = values.video ?? false;
-    const captureType = isVideo ? 'GIF' : 'screenshot';
-    console.log(`Capturing ${captureType} before: ${beforeUrl}${beforeSelector ? ` (${beforeSelector})` : ''}`);
-    console.log(`Capturing ${captureType} after:  ${afterUrl}${afterSelector ? ` (${afterSelector})` : ''}`);
+    console.log(`Capturing before: ${beforeUrl}${beforeSelector ? ` (${beforeSelector})` : ''}`);
+    console.log(`Capturing after:  ${afterUrl}${afterSelector ? ` (${afterSelector})` : ''}`);
 
-    if (isVideo) {
-      // Video/GIF mode
-      const resolvedViewport = resolveViewport(viewport);
-      const videoOpts = {
-        viewport: resolvedViewport,
-        duration: values.duration ? parseFloat(values.duration) : undefined,
-        fps: values.fps ? parseInt(values.fps) : undefined,
-        delay: values.delay ? parseInt(values.delay) : undefined,
+    const result = await ba.captureBeforeAfter({
+      before: {
+        url: beforeUrl,
         selector: beforeSelector,
-      };
+        fullPage: values.full,
+      },
+      after: {
+        url: afterUrl,
+        selector: afterSelector,
+        fullPage: values.full,
+      },
+    });
 
-      const beforeResult = await captureVideo(beforeUrl, videoOpts);
-      const afterResult = await captureVideo(afterUrl, { ...videoOpts, selector: afterSelector });
+    // Generate filenames
+    const timestamp = new Date();
+    const beforeFilename = generateFilename({
+      url: beforeUrl,
+      suffix: 'before',
+      timestamp,
+    });
 
-      const timestamp = new Date();
-      const beforeFilename = generateFilename({ url: beforeUrl, suffix: 'before', timestamp, format: 'gif' });
-      const afterFilename = generateFilename({ url: afterUrl, suffix: 'after', timestamp, format: 'gif' });
+    const afterFilename = generateFilename({
+      url: afterUrl,
+      suffix: 'after',
+      timestamp,
+    });
 
-      const beforePath = path.join(outputDir, beforeFilename);
-      const afterPath = path.join(outputDir, afterFilename);
-      fs.writeFileSync(beforePath, beforeResult.gif);
-      fs.writeFileSync(afterPath, afterResult.gif);
-      console.log(`\nSaved: ${beforePath} (${beforeResult.frameCount} frames)`);
-      console.log(`Saved: ${afterPath} (${afterResult.frameCount} frames)`);
+    const beforePath = path.join(outputDir, beforeFilename);
+    const afterPath = path.join(outputDir, afterFilename);
+    fs.writeFileSync(beforePath, result.before.image);
+    fs.writeFileSync(afterPath, result.after.image);
+    console.log(`\nSaved: ${beforePath}`);
+    console.log(`Saved: ${afterPath}`);
 
-      if (values.markdown) {
-        await uploadAndOutputMarkdown(beforeResult.gif, afterResult.gif, beforeFilename, afterFilename);
-      }
-    } else {
-      // Static screenshot mode
-      const result = await ba.captureBeforeAfter({
-        before: {
-          url: beforeUrl,
-          selector: beforeSelector,
-          fullPage: values.full,
-        },
-        after: {
-          url: afterUrl,
-          selector: afterSelector,
-          fullPage: values.full,
-        },
-      });
+    // Output markdown if requested
+    if (values.markdown) {
+      const uploadUrl = values['upload-url'] || process.env.UPLOAD_URL;
+      console.log(`\nUploading images${uploadUrl ? ` to ${uploadUrl}` : ''}...`);
 
-      const timestamp = new Date();
-      const beforeFilename = generateFilename({ url: beforeUrl, suffix: 'before', timestamp });
-      const afterFilename = generateFilename({ url: afterUrl, suffix: 'after', timestamp });
+      const { beforeUrl: bUrl, afterUrl: aUrl } = await uploadBeforeAfter(
+        { image: result.before.image, filename: beforeFilename },
+        { image: result.after.image, filename: afterFilename },
+        uploadUrl
+      );
 
-      const beforePath = path.join(outputDir, beforeFilename);
-      const afterPath = path.join(outputDir, afterFilename);
-      fs.writeFileSync(beforePath, result.before.image);
-      fs.writeFileSync(afterPath, result.after.image);
-      console.log(`\nSaved: ${beforePath}`);
-      console.log(`Saved: ${afterPath}`);
+      console.log(`Before: ${bUrl}`);
+      console.log(`After:  ${aUrl}`);
 
-      if (values.markdown) {
-        await uploadAndOutputMarkdown(
-          result.before.image,
-          result.after.image,
-          beforeFilename,
-          afterFilename,
-        );
+      const markdown = `| Pre | Post |
+|:---:|:----:|
+| ![Pre](${bUrl}) | ![Post](${aUrl}) |`;
+
+      console.log(`\n${markdown}`);
+
+      if (copyToClipboard(markdown)) {
+        console.log(`\nMarkdown copied to clipboard`);
       }
     }
   } finally {
@@ -510,36 +403,6 @@ function formatTimestamp(date: Date): string {
   return date.toISOString().replace(/[:.]/g, '-').slice(0, 19);
 }
 
-function buildMarkdownTable(beforeUrl: string, afterUrl: string): string {
-  const header = '| Pre | Post |';
-  const divider = '|:---:|:----:|';
-  const row = `| ![Pre](${beforeUrl}) | ![Post](${afterUrl}) |`;
-  return `${header}\n${divider}\n${row}`;
-}
-
-async function uploadAndOutputMarkdown(
-  beforeImage: Buffer,
-  afterImage: Buffer,
-  beforeFilename: string,
-  afterFilename: string,
-): Promise<void> {
-  const uploadUrl = values['upload-url'] || process.env.UPLOAD_URL;
-  console.log(`Uploading images${uploadUrl ? ` to ${uploadUrl}` : ''}...`);
-
-  const { beforeUrl, afterUrl } = await uploadBeforeAfter(
-    { image: beforeImage, filename: beforeFilename },
-    { image: afterImage, filename: afterFilename },
-    uploadUrl,
-  );
-
-  const markdown = buildMarkdownTable(beforeUrl, afterUrl);
-  console.log(`\n${markdown}`);
-
-  if (copyToClipboard(markdown)) {
-    console.log('\nMarkdown copied to clipboard');
-  }
-}
-
 // ============================================================
 // Main dispatch
 // ============================================================
@@ -548,8 +411,6 @@ async function main(): Promise<void> {
     printHelp();
     return;
   }
-
-  validateVideoFlags();
 
   switch (subcommand) {
     case 'detect':

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -7,9 +7,11 @@ import { BeforeAndAfter, generateFilename } from '../index.js';
 import { ViewportConfig, VIEWPORT_PRESETS } from '../types.js';
 import { closeBrowser } from '../browser.js';
 import { captureScreenshot, captureResponsive } from '../capture.js';
+import { captureVideo } from '../video.js';
 import { uploadBeforeAfter } from '../upload.js';
 import { copyToClipboard } from '../clipboard.js';
 import { detectRoutes, getChangedFiles, detectFramework } from '../routes.js';
+import { resolveViewport } from '../viewport.js';
 
 // Determine subcommand
 const subcommand = process.argv[2];
@@ -42,6 +44,11 @@ const { values, positionals } = parseArgs({
     framework: { type: 'string' },
     'before-base': { type: 'string' },
     'after-base': { type: 'string' },
+    // Video/GIF options
+    video: { type: 'boolean' },
+    duration: { type: 'string' },
+    fps: { type: 'string' },
+    delay: { type: 'string' },
   },
 });
 
@@ -83,6 +90,12 @@ COMPARE OPTIONS:
       --before-base <url>    Base URL for "before" state (production)
       --after-base <url>     Base URL for "after" state (localhost)
 
+VIDEO OPTIONS:
+      --video                Capture animated GIF instead of static screenshot
+      --duration <seconds>   Recording duration (default: 3, max: 10)
+      --fps <n>              Target frames per second (default: 5, max: 10)
+      --delay <ms>           Wait after page load before recording (default: 0)
+
 OUTPUT OPTIONS:
   -o, --output <dir>         Output directory (default: ~/Downloads)
       --markdown             Upload images & output markdown table
@@ -110,6 +123,13 @@ EXAMPLES:
   # Responsive capture (desktop + mobile)
   pre-post compare --before-base url1 --after-base url2 --responsive
 
+  # Capture animated GIFs instead of static screenshots
+  pre-post google.com facebook.com --video
+  pre-post google.com facebook.com --video --duration 5 --fps 8
+
+  # GIF capture with compare mode
+  pre-post compare --before-base url1 --after-base url2 --video --delay 500
+
   # Use existing images (auto-detected)
   pre-post before.png after.png --markdown
 `);
@@ -130,6 +150,30 @@ function normalizeUrl(url: string): string {
     return `http://${url}`;
   }
   return `https://${url}`;
+}
+
+/**
+ * Validate --video flag combinations and parse video-related options.
+ */
+function validateVideoFlags(): void {
+  if (!values.video) return;
+
+  if (values.full) {
+    console.error('--full (fullPage) is not supported with --video');
+    process.exit(1);
+  }
+
+  const duration = values.duration ? parseFloat(values.duration) : 3;
+  if (duration <= 0 || duration > 10) {
+    console.error('Duration must be between 0.1 and 10 seconds');
+    process.exit(1);
+  }
+
+  const fps = values.fps ? parseInt(values.fps) : 5;
+  if (fps < 1 || fps > 10) {
+    console.error('FPS must be between 1 and 10');
+    process.exit(1);
+  }
 }
 
 function resolveViewportFlag(): ViewportConfig {
@@ -192,58 +236,99 @@ async function runCompare(): Promise<void> {
 
   const timestamp = new Date();
 
+  const isVideo = values.video ?? false;
+  const ext = isVideo ? 'gif' : 'png';
+  const captureType = isVideo ? 'GIF' : 'screenshot';
+
   try {
     for (const route of routeList) {
       const beforeUrl = normalizeUrl(beforeBase.replace(/\/$/, '') + route);
       const afterUrl = normalizeUrl(afterBase.replace(/\/$/, '') + route);
+      const routeSlug = route === '/' ? 'home' : route.replace(/^\//, '').replace(/\//g, '-');
 
       if (responsive) {
         // Capture desktop + mobile for each route
         for (const preset of ['desktop', 'mobile'] as const) {
           const vp = VIEWPORT_PRESETS[preset];
+          console.log(`Capturing ${captureType} ${route} @ ${preset} (${vp.width}x${vp.height})...`);
 
-          console.log(`Capturing ${route} @ ${preset} (${vp.width}x${vp.height})...`);
+          if (isVideo) {
+            const videoOpts = {
+              viewport: vp,
+              duration: values.duration ? parseFloat(values.duration) : undefined,
+              fps: values.fps ? parseInt(values.fps) : undefined,
+              delay: values.delay ? parseInt(values.delay) : undefined,
+              selector: values.selector,
+            };
 
-          const beforeResult = await captureScreenshot({
-            url: beforeUrl,
-            viewport: preset,
-            fullPage: values.full,
+            const beforeResult = await captureVideo(beforeUrl, videoOpts);
+            const afterResult = await captureVideo(afterUrl, videoOpts);
+
+            const beforeFilename = `${routeSlug}-${preset}-before-${formatTimestamp(timestamp)}.${ext}`;
+            const afterFilename = `${routeSlug}-${preset}-after-${formatTimestamp(timestamp)}.${ext}`;
+
+            fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.gif);
+            fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.gif);
+            console.log(`  Saved: ${beforeFilename} (${beforeResult.frameCount}f), ${afterFilename} (${afterResult.frameCount}f)`);
+          } else {
+            const beforeResult = await captureScreenshot({
+              url: beforeUrl,
+              viewport: preset,
+              fullPage: values.full,
+              selector: values.selector,
+            });
+            const afterResult = await captureScreenshot({
+              url: afterUrl,
+              viewport: preset,
+              fullPage: values.full,
+              selector: values.selector,
+            });
+
+            const beforeFilename = `${routeSlug}-${preset}-before-${formatTimestamp(timestamp)}.${ext}`;
+            const afterFilename = `${routeSlug}-${preset}-after-${formatTimestamp(timestamp)}.${ext}`;
+
+            fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.image);
+            fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.image);
+            console.log(`  Saved: ${beforeFilename}, ${afterFilename}`);
+          }
+        }
+      } else {
+        console.log(`Capturing ${captureType} ${route}...`);
+
+        if (isVideo) {
+          const resolvedVp = resolveViewport(viewport);
+          const videoOpts = {
+            viewport: resolvedVp,
+            duration: values.duration ? parseFloat(values.duration) : undefined,
+            fps: values.fps ? parseInt(values.fps) : undefined,
+            delay: values.delay ? parseInt(values.delay) : undefined,
             selector: values.selector,
-          });
-          const afterResult = await captureScreenshot({
-            url: afterUrl,
-            viewport: preset,
-            fullPage: values.full,
-            selector: values.selector,
-          });
+          };
 
-          const routeSlug = route === '/' ? 'home' : route.replace(/^\//, '').replace(/\//g, '-');
-          const beforeFilename = `${routeSlug}-${preset}-before-${formatTimestamp(timestamp)}.png`;
-          const afterFilename = `${routeSlug}-${preset}-after-${formatTimestamp(timestamp)}.png`;
+          const beforeResult = await captureVideo(beforeUrl, videoOpts);
+          const afterResult = await captureVideo(afterUrl, videoOpts);
+
+          const beforeFilename = `${routeSlug}-before-${formatTimestamp(timestamp)}.${ext}`;
+          const afterFilename = `${routeSlug}-after-${formatTimestamp(timestamp)}.${ext}`;
+
+          fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.gif);
+          fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.gif);
+          console.log(`  Saved: ${beforeFilename} (${beforeResult.frameCount}f), ${afterFilename} (${afterResult.frameCount}f)`);
+        } else {
+          const beforeResult = await captureScreenshot({ url: beforeUrl, viewport, fullPage: values.full });
+          const afterResult = await captureScreenshot({ url: afterUrl, viewport, fullPage: values.full });
+
+          const beforeFilename = `${routeSlug}-before-${formatTimestamp(timestamp)}.${ext}`;
+          const afterFilename = `${routeSlug}-after-${formatTimestamp(timestamp)}.${ext}`;
 
           fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.image);
           fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.image);
-
           console.log(`  Saved: ${beforeFilename}, ${afterFilename}`);
         }
-      } else {
-        console.log(`Capturing ${route}...`);
-
-        const beforeResult = await captureScreenshot({ url: beforeUrl, viewport, fullPage: values.full });
-        const afterResult = await captureScreenshot({ url: afterUrl, viewport, fullPage: values.full });
-
-        const routeSlug = route === '/' ? 'home' : route.replace(/^\//, '').replace(/\//g, '-');
-        const beforeFilename = `${routeSlug}-before-${formatTimestamp(timestamp)}.png`;
-        const afterFilename = `${routeSlug}-after-${formatTimestamp(timestamp)}.png`;
-
-        fs.writeFileSync(path.join(outputDir, beforeFilename), beforeResult.image);
-        fs.writeFileSync(path.join(outputDir, afterFilename), afterResult.image);
-
-        console.log(`  Saved: ${beforeFilename}, ${afterFilename}`);
       }
     }
 
-    console.log(`\nAll screenshots saved to: ${outputDir}`);
+    console.log(`\nAll ${captureType}s saved to: ${outputDir}`);
   } finally {
     await closeBrowser();
   }
@@ -348,50 +433,73 @@ async function runDefault(): Promise<void> {
     const outputDir = values.output || path.join(process.env.HOME || '~', 'Downloads');
     fs.mkdirSync(outputDir, { recursive: true });
 
-    console.log(`Capturing before: ${beforeUrl}${beforeSelector ? ` (${beforeSelector})` : ''}`);
-    console.log(`Capturing after:  ${afterUrl}${afterSelector ? ` (${afterSelector})` : ''}`);
+    const isVideo = values.video ?? false;
+    const captureType = isVideo ? 'GIF' : 'screenshot';
+    console.log(`Capturing ${captureType} before: ${beforeUrl}${beforeSelector ? ` (${beforeSelector})` : ''}`);
+    console.log(`Capturing ${captureType} after:  ${afterUrl}${afterSelector ? ` (${afterSelector})` : ''}`);
 
-    const result = await ba.captureBeforeAfter({
-      before: {
-        url: beforeUrl,
+    if (isVideo) {
+      // Video/GIF mode
+      const resolvedViewport = resolveViewport(viewport);
+      const videoOpts = {
+        viewport: resolvedViewport,
+        duration: values.duration ? parseFloat(values.duration) : undefined,
+        fps: values.fps ? parseInt(values.fps) : undefined,
+        delay: values.delay ? parseInt(values.delay) : undefined,
         selector: beforeSelector,
-        fullPage: values.full,
-      },
-      after: {
-        url: afterUrl,
-        selector: afterSelector,
-        fullPage: values.full,
-      },
-    });
+      };
 
-    // Generate filenames
-    const timestamp = new Date();
-    const beforeFilename = generateFilename({
-      url: beforeUrl,
-      suffix: 'before',
-      timestamp,
-    });
+      const beforeResult = await captureVideo(beforeUrl, videoOpts);
+      const afterResult = await captureVideo(afterUrl, { ...videoOpts, selector: afterSelector });
 
-    const afterFilename = generateFilename({
-      url: afterUrl,
-      suffix: 'after',
-      timestamp,
-    });
+      const timestamp = new Date();
+      const beforeFilename = generateFilename({ url: beforeUrl, suffix: 'before', timestamp, format: 'gif' });
+      const afterFilename = generateFilename({ url: afterUrl, suffix: 'after', timestamp, format: 'gif' });
 
-    const beforePath = path.join(outputDir, beforeFilename);
-    const afterPath = path.join(outputDir, afterFilename);
-    fs.writeFileSync(beforePath, result.before.image);
-    fs.writeFileSync(afterPath, result.after.image);
-    console.log(`\nSaved: ${beforePath}`);
-    console.log(`Saved: ${afterPath}`);
+      const beforePath = path.join(outputDir, beforeFilename);
+      const afterPath = path.join(outputDir, afterFilename);
+      fs.writeFileSync(beforePath, beforeResult.gif);
+      fs.writeFileSync(afterPath, afterResult.gif);
+      console.log(`\nSaved: ${beforePath} (${beforeResult.frameCount} frames)`);
+      console.log(`Saved: ${afterPath} (${afterResult.frameCount} frames)`);
 
-    if (values.markdown) {
-      await uploadAndOutputMarkdown(
-        result.before.image,
-        result.after.image,
-        beforeFilename,
-        afterFilename,
-      );
+      if (values.markdown) {
+        await uploadAndOutputMarkdown(beforeResult.gif, afterResult.gif, beforeFilename, afterFilename);
+      }
+    } else {
+      // Static screenshot mode
+      const result = await ba.captureBeforeAfter({
+        before: {
+          url: beforeUrl,
+          selector: beforeSelector,
+          fullPage: values.full,
+        },
+        after: {
+          url: afterUrl,
+          selector: afterSelector,
+          fullPage: values.full,
+        },
+      });
+
+      const timestamp = new Date();
+      const beforeFilename = generateFilename({ url: beforeUrl, suffix: 'before', timestamp });
+      const afterFilename = generateFilename({ url: afterUrl, suffix: 'after', timestamp });
+
+      const beforePath = path.join(outputDir, beforeFilename);
+      const afterPath = path.join(outputDir, afterFilename);
+      fs.writeFileSync(beforePath, result.before.image);
+      fs.writeFileSync(afterPath, result.after.image);
+      console.log(`\nSaved: ${beforePath}`);
+      console.log(`Saved: ${afterPath}`);
+
+      if (values.markdown) {
+        await uploadAndOutputMarkdown(
+          result.before.image,
+          result.after.image,
+          beforeFilename,
+          afterFilename,
+        );
+      }
     }
   } finally {
     await closeBrowser();
@@ -440,6 +548,8 @@ async function main(): Promise<void> {
     printHelp();
     return;
   }
+
+  validateVideoFlags();
 
   switch (subcommand) {
     case 'detect':

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,6 +11,17 @@ import path from 'path';
 let browser: Browser | null = null;
 let page: Page | null = null;
 
+/**
+ * Get the shared Browser instance (creating it if needed).
+ * Used by video.ts to create fresh pages without animation-killing CSS.
+ */
+export async function getBrowser(): Promise<Browser> {
+  if (!browser) {
+    browser = await launchBrowser();
+  }
+  return browser;
+}
+
 export interface ScreenshotOptions {
   viewport: ViewportSize;
   fullPage?: boolean;

--- a/src/filename.ts
+++ b/src/filename.ts
@@ -9,6 +9,8 @@ export interface FilenameOptions {
   timestamp?: Date;
   /** Suffix (before/after/diff) */
   suffix?: 'before' | 'after' | 'diff';
+  /** Output format — determines file extension (default: 'png') */
+  format?: 'png' | 'gif';
 }
 
 /**
@@ -93,5 +95,6 @@ export function generateFilename(options: FilenameOptions): string {
     .replace(/[:.]/g, '-')
     .slice(0, 19);
 
-  return `${pageName}${elementPart}${suffixPart}-${timestamp}.png`;
+  const ext = options.format === 'gif' ? 'gif' : 'png';
+  return `${pageName}${elementPart}${suffixPart}-${timestamp}.${ext}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types.js';
 export { resolveViewport } from './viewport.js';
 export { captureScreenshot, captureBeforeAfter, captureResponsive } from './capture.js';
+export { captureVideo, captureGif } from './video.js';
 export { generateFilename } from './filename.js';
 export { closeBrowser, readScreenshot } from './browser.js';
 export { detectRoutes, detectFramework, getChangedFiles } from './routes.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,3 +134,37 @@ export interface CompareOptions {
   /** Generate markdown output */
   markdown?: boolean;
 }
+
+// ============================================================
+// Video/GIF Capture
+// ============================================================
+
+export interface VideoOptions {
+  /** Viewport size for the capture */
+  viewport: ViewportSize;
+  /** Recording duration in seconds (default: 3, max: 10) */
+  duration?: number;
+  /** Target frames per second (default: 5, max: 10) */
+  fps?: number;
+  /** Milliseconds to wait after page load before recording (default: 0) */
+  delay?: number;
+  /** CSS selector — scroll element into view before recording */
+  selector?: string;
+}
+
+export interface VideoResult {
+  /** Raw GIF data */
+  gif: Buffer;
+  /** Output format identifier */
+  format: 'gif';
+  /** Viewport used for capture */
+  viewport: ViewportSize;
+  /** URL that was captured */
+  url: string;
+  /** Actual recording duration in seconds */
+  duration: number;
+  /** Number of frames in the GIF */
+  frameCount: number;
+  /** CSS selector used, if any */
+  selector?: string;
+}

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -51,9 +51,10 @@ async function upload0x0st(image: Buffer, filename: string, url: string): Promis
 }
 
 async function uploadVercelBlob(image: Buffer, filename: string, url: string): Promise<string> {
+  const contentType = filename.endsWith('.gif') ? 'image/gif' : 'image/png';
   const response = await fetch(`${url}/${filename}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'image/png' },
+    headers: { 'Content-Type': contentType },
     body: image,
   });
 
@@ -66,9 +67,10 @@ async function uploadVercelBlob(image: Buffer, filename: string, url: string): P
 }
 
 async function uploadGenericPut(image: Buffer, filename: string, url: string): Promise<string> {
+  const mimeType = filename.endsWith('.gif') ? 'image/gif' : 'image/png';
   const response = await fetch(`${url}/${filename}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'image/png' },
+    headers: { 'Content-Type': mimeType },
     body: image,
   });
 
@@ -118,6 +120,14 @@ export function uploadGitNative(
   image: Buffer,
   filename: string,
 ): { filename: string; ownerRepo: string } {
+  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+  if (image.length > MAX_FILE_SIZE) {
+    const sizeMB = (image.length / 1024 / 1024).toFixed(1);
+    throw new Error(
+      `File is ${sizeMB} MB (limit: 10 MB). Reduce --duration or --fps.`
+    );
+  }
+
   const repoRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
   const ownerRepo = resolveOwnerRepo();
 

--- a/src/video.ts
+++ b/src/video.ts
@@ -1,23 +1,16 @@
 /**
- * Video/GIF capture via sequential Playwright screenshots + gifenc encoding.
+ * Animated GIF capture via sequential Playwright screenshots + gifenc encoding.
  *
- * Captures frames at ~100ms intervals (≈10 FPS) and stitches them into
- * an animated GIF. Designed for short clips (1–5 seconds) of page load
- * animations, CSS transitions, and layout changes.
- *
- * When FFmpeg is available, an alternative path uses Playwright's native
- * recordVideo (WebM) + FFmpeg palette-optimized conversion for higher quality.
+ * Pipeline: JPEG screenshots → canvas decode → gifenc quantize → animated GIF.
+ * Single codepath. No FFmpeg. No external dependencies beyond Playwright + gifenc.
  */
 
-import { Browser, Page, BrowserContext } from 'playwright';
-import { ViewportSize } from './types.js';
-import { execSync } from 'child_process';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-
-// gifenc ships as CJS bundle — use createRequire for ESM compat
+import { Browser, Page } from 'playwright';
+import { VideoOptions, VideoResult, ViewportSize } from './types.js';
+import { getBrowser } from './browser.js';
 import { createRequire } from 'module';
+
+// gifenc ships as CJS — use createRequire for ESM compat
 const require = createRequire(import.meta.url);
 const {
   GIFEncoder,
@@ -38,86 +31,101 @@ interface GifEncoder {
   ) => void;
   finish: () => void;
   bytes: () => Uint8Array;
-  bytesView: () => Uint8Array;
 }
 
+// Mobile viewport height cap for GIF mode (above-the-fold, not comically tall)
+const MOBILE_GIF_HEIGHT = 667;
+
 // ============================================================
-// Public types
+// Canvas decoder page (reused across frames)
 // ============================================================
 
-export interface VideoOptions {
-  /** Viewport size for the capture. */
-  viewport: ViewportSize;
-  /** Recording duration in seconds. Default: 2 */
-  duration?: number;
-  /** Target FPS for GIF output. Default: 8 */
-  fps?: number;
-  /** CSS selector — scroll element into view before recording. */
-  selector?: string;
-  /** Capture full scrollable page. Default: false */
-  fullPage?: boolean;
-  /** Scale factor for GIF output relative to viewport. Default: 0.5 (half-res) */
-  gifScale?: number;
+let decoderPage: Page | null = null;
+
+async function getDecoderPage(browser: Browser): Promise<Page> {
+  if (decoderPage && !decoderPage.isClosed()) return decoderPage;
+  decoderPage = await browser.newPage();
+  await decoderPage.setContent('<canvas id="c"></canvas>');
+  return decoderPage;
 }
 
-export interface VideoResult {
-  /** Raw GIF data */
-  gif: Buffer;
-  /** Output format identifier */
-  format: 'gif';
-  /** Viewport used for capture */
-  viewport: ViewportSize;
-  /** URL that was captured */
-  url: string;
-  /** Actual recording duration in seconds */
-  duration: number;
-  /** Number of frames in the GIF */
-  frameCount: number;
-  /** CSS selector used, if any */
-  selector?: string;
-}
-
-// ============================================================
-// FFmpeg detection (cached)
-// ============================================================
-
-let ffmpegAvailable: boolean | null = null;
-
-function hasFfmpeg(): boolean {
-  if (ffmpegAvailable !== null) return ffmpegAvailable;
-  try {
-    execSync('which ffmpeg', { stdio: 'pipe' });
-    ffmpegAvailable = true;
-  } catch {
-    ffmpegAvailable = false;
+async function closeDecoderPage(): Promise<void> {
+  if (decoderPage && !decoderPage.isClosed()) {
+    await decoderPage.close();
+    decoderPage = null;
   }
-  return ffmpegAvailable;
+}
+
+/**
+ * Decode a JPEG buffer to raw RGBA pixels at target dimensions.
+ * Uses a hidden Playwright page with canvas for decoding.
+ */
+async function decodeJpegToRgba(
+  browser: Browser,
+  jpegBuffer: Buffer,
+  width: number,
+  height: number,
+): Promise<Uint8Array> {
+  const pg = await getDecoderPage(browser);
+  const base64 = jpegBuffer.toString('base64');
+
+  const rawPixels = await pg.evaluate(
+    async ({ b64, w, h }: { b64: string; w: number; h: number }) => {
+      const img = new Image();
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = reject;
+        img.src = `data:image/jpeg;base64,${b64}`;
+      });
+
+      const canvas = document.getElementById('c') as HTMLCanvasElement;
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(img, 0, 0, w, h);
+      const imageData = ctx.getImageData(0, 0, w, h);
+      return Array.from(imageData.data);
+    },
+    { b64: base64, w: width, h: height },
+  );
+
+  return new Uint8Array(rawPixels);
 }
 
 // ============================================================
-// Path B: Sequential screenshots → gifenc (default)
+// Core capture function
 // ============================================================
 
 /**
- * Capture a short animated GIF by taking rapid sequential screenshots.
- *
- * This is the default path — zero external dependencies beyond Playwright.
- * Produces ~8 FPS GIFs which is sufficient for most CSS transitions.
+ * Capture animated GIF frames from an existing Playwright Page.
+ * Caller manages page lifecycle.
  */
 export async function captureGif(
   page: Page,
   url: string,
   options: VideoOptions,
 ): Promise<VideoResult> {
-  const duration = options.duration ?? 2;
-  const fps = options.fps ?? 8;
-  const gifScale = options.gifScale ?? 0.5;
+  const duration = options.duration ?? 3;
+  const fps = options.fps ?? 5;
+  const delay = options.delay ?? 0;
   const totalFrames = Math.ceil(duration * fps);
-  const frameDelay = Math.round(1000 / fps);
+  const frameInterval = Math.round(1000 / fps);
 
-  // Navigate WITHOUT killing animations (unlike screenshot path)
-  await page.goto(url, { waitUntil: 'networkidle' });
+  // Navigate — do NOT kill animations
+  const response = await page.goto(url, { waitUntil: 'networkidle' });
+
+  // Warn on HTTP errors (but continue — page may still have content)
+  if (response && response.status() >= 400) {
+    console.warn(`Warning: ${url} returned HTTP ${response.status()}`);
+  }
+
+  // Wait for fonts
   await page.evaluate(() => document.fonts.ready);
+
+  // Optional delay before recording
+  if (delay > 0) {
+    await page.waitForTimeout(delay);
+  }
 
   // Scroll selector into view if specified
   if (options.selector) {
@@ -130,21 +138,35 @@ export async function captureGif(
     await page.waitForTimeout(100);
   }
 
-  // Capture frames
+  // Capture JPEG frames
   const frames: Buffer[] = [];
+  let identicalCount = 0;
+
   for (let i = 0; i < totalFrames; i++) {
-    const screenshot = await page.screenshot({ fullPage: options.fullPage ?? false });
-    frames.push(Buffer.from(screenshot));
+    const screenshot = await page.screenshot({ type: 'jpeg', quality: 80 });
+    const frame = Buffer.from(screenshot);
+
+    // Early-stop: 3 consecutive identical frames means animation has settled
+    if (frames.length > 0 && frame.equals(frames[frames.length - 1])) {
+      identicalCount++;
+      if (identicalCount >= 3) {
+        console.log(`Animation settled after ${i} frames`);
+        break;
+      }
+    } else {
+      identicalCount = 0;
+    }
+
+    frames.push(frame);
+
     if (i < totalFrames - 1) {
-      await page.waitForTimeout(frameDelay);
+      await page.waitForTimeout(frameInterval);
     }
   }
 
   // Encode GIF
-  const gifBuffer = await encodeGif(frames, options.viewport, {
-    fps,
-    scale: gifScale,
-  });
+  const browser = await getBrowser();
+  const gifBuffer = await encodeGif(browser, frames, options.viewport, fps);
 
   return {
     gif: gifBuffer,
@@ -158,249 +180,71 @@ export async function captureGif(
 }
 
 // ============================================================
-// Path A: Playwright recordVideo + FFmpeg (higher quality)
+// High-level entry point
 // ============================================================
 
 /**
- * Capture a short animated GIF using Playwright's native video recording
- * and FFmpeg conversion. Produces smoother output (30+ FPS source).
- *
- * Requires FFmpeg installed on the system.
- */
-export async function captureGifWithVideo(
-  browser: Browser,
-  url: string,
-  options: VideoOptions,
-): Promise<VideoResult> {
-  const duration = options.duration ?? 2;
-  const fps = options.fps ?? 10;
-  const gifScale = options.gifScale ?? 0.5;
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pre-post-video-'));
-
-  const context = await browser.newContext({
-    viewport: options.viewport,
-    deviceScaleFactor: 1, // Record at 1x for video (keeps file size sane)
-    recordVideo: { dir: tmpDir, size: options.viewport },
-  });
-
-  const page = await context.newPage();
-
-  await page.goto(url, { waitUntil: 'networkidle' });
-  await page.evaluate(() => document.fonts.ready);
-
-  if (options.selector) {
-    const locator = page.locator(options.selector);
-    const count = await locator.count();
-    if (count === 0) {
-      await context.close();
-      throw new Error(`Element not found: ${options.selector}`);
-    }
-    await locator.first().scrollIntoViewIfNeeded();
-  }
-
-  // Let animations play
-  await page.waitForTimeout(duration * 1000);
-
-  // Close context to finalize video file
-  const video = page.video();
-  const videoPath = video ? await video.path() : null;
-  await context.close();
-
-  if (!videoPath || !fs.existsSync(videoPath)) {
-    throw new Error('Playwright video recording failed — no output file produced');
-  }
-
-  // Convert WebM → GIF via FFmpeg (two-pass palette optimization)
-  const gifPath = path.join(tmpDir, 'output.gif');
-  const palettePath = path.join(tmpDir, 'palette.png');
-  const gifW = Math.round(options.viewport.width * gifScale);
-
-  try {
-    execSync(
-      `ffmpeg -i "${videoPath}" -vf "fps=${fps},scale=${gifW}:-1:flags=lanczos,palettegen=stats_mode=diff" -y "${palettePath}"`,
-      { stdio: 'pipe', timeout: 15000 },
-    );
-    execSync(
-      `ffmpeg -i "${videoPath}" -i "${palettePath}" -lavfi "fps=${fps},scale=${gifW}:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5" -y "${gifPath}"`,
-      { stdio: 'pipe', timeout: 15000 },
-    );
-
-    const gifBuffer = fs.readFileSync(gifPath);
-
-    return {
-      gif: Buffer.from(gifBuffer),
-      format: 'gif',
-      viewport: options.viewport,
-      url,
-      duration,
-      frameCount: Math.ceil(duration * fps),
-      selector: options.selector,
-    };
-  } finally {
-    // Clean up temp files
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
-  }
-}
-
-// ============================================================
-// GIF encoding (pure JS via gifenc)
-// ============================================================
-
-interface EncodeOptions {
-  fps: number;
-  scale: number;
-}
-
-/**
- * Encode an array of PNG screenshot Buffers into an animated GIF.
- * Uses gifenc for quantization and LZW encoding.
- */
-async function encodeGif(
-  frames: Buffer[],
-  viewport: ViewportSize,
-  options: EncodeOptions,
-): Promise<Buffer> {
-  // We need to decode PNG frames to raw RGBA pixels.
-  // Use a canvas-free approach: Playwright screenshots are PNG,
-  // we can use the sharp-free method of creating an offscreen page.
-  // But simpler: just use the raw pixel data from Playwright's screenshot API.
-  //
-  // Actually, Playwright returns PNG-encoded buffers. We need raw RGBA data.
-  // The simplest approach without adding sharp: decode PNG manually.
-  // We'll use a minimal PNG decoder.
-
-  const gifWidth = Math.round(viewport.width * options.scale);
-  const gifHeight = Math.round(viewport.height * options.scale);
-  const delay = Math.round(1000 / options.fps / 10); // GIF delay is in centiseconds
-
-  const encoder = GIFEncoder();
-
-  for (let i = 0; i < frames.length; i++) {
-    // Decode PNG to raw RGBA using built-in approach
-    const rgba = await decodePngToRgba(frames[i], gifWidth, gifHeight);
-
-    // Quantize to 256-color palette
-    const palette = quantize(rgba, 256, { format: 'rgba4444' });
-    const indexed = applyPalette(rgba, palette, 'rgba4444');
-
-    encoder.writeFrame(indexed, gifWidth, gifHeight, {
-      palette,
-      delay,
-      repeat: 0, // loop forever
-      dispose: i === 0 ? -1 : 0,
-    });
-  }
-
-  encoder.finish();
-  return Buffer.from(encoder.bytes());
-}
-
-/**
- * Decode a PNG buffer to raw RGBA pixel data at a target resolution.
- *
- * Uses Playwright's page.evaluate to leverage the browser's built-in
- * PNG decoder + canvas scaling. This avoids adding sharp/canvas as a dep.
- *
- * Falls back to a simple approach using the existing Playwright page.
- */
-let decoderPage: Page | null = null;
-let decoderBrowser: Browser | null = null;
-
-async function getDecoderPage(browser: Browser): Promise<Page> {
-  if (decoderPage && !decoderPage.isClosed()) return decoderPage;
-  decoderBrowser = browser;
-  decoderPage = await browser.newPage();
-  await decoderPage.setContent('<canvas id="c"></canvas>');
-  return decoderPage;
-}
-
-/**
- * Minimal PNG decoder — decodes PNG to raw RGBA at target dimensions.
- * Leverages the browser's native image decoding via a hidden canvas.
- */
-async function decodePngToRgba(
-  pngBuffer: Buffer,
-  targetWidth: number,
-  targetHeight: number,
-): Promise<Uint8Array> {
-  // We'll use a simple inline approach: convert PNG to data URL,
-  // then use OffscreenCanvas or Canvas to decode and resize.
-  // This works because we already have a Playwright browser running.
-
-  // For now, use the simpler approach of importing the PNG as raw pixels
-  // via a data URL in the browser context.
-
-  // Get a page from the module-level browser
-  const { getBrowser } = await import('./browser.js');
-  const browser = await getBrowser();
-  const pg = await getDecoderPage(browser);
-
-  const base64 = pngBuffer.toString('base64');
-
-  const rawPixels = await pg.evaluate(
-    async ({ b64, w, h }: { b64: string; w: number; h: number }) => {
-      const img = new Image();
-      await new Promise<void>((resolve, reject) => {
-        img.onload = () => resolve();
-        img.onerror = reject;
-        img.src = `data:image/png;base64,${b64}`;
-      });
-
-      const canvas = document.getElementById('c') as HTMLCanvasElement;
-      canvas.width = w;
-      canvas.height = h;
-      const ctx = canvas.getContext('2d')!;
-      ctx.drawImage(img, 0, 0, w, h);
-      const imageData = ctx.getImageData(0, 0, w, h);
-      return Array.from(imageData.data);
-    },
-    { b64: base64, w: targetWidth, h: targetHeight },
-  );
-
-  return new Uint8Array(rawPixels);
-}
-
-/**
- * Close the decoder page used for PNG→RGBA conversion.
- * Should be called during cleanup.
- */
-export async function closeDecoderPage(): Promise<void> {
-  if (decoderPage && !decoderPage.isClosed()) {
-    await decoderPage.close();
-    decoderPage = null;
-  }
-}
-
-// ============================================================
-// Main entry point — auto-selects best available path
-// ============================================================
-
-/**
- * Capture a short animated GIF of a URL.
- * Automatically selects the best recording method:
- * - FFmpeg path (higher quality) when FFmpeg is available
- * - Sequential screenshot path (zero deps) as default
+ * Capture an animated GIF of a URL.
+ * Creates its own page at DPR 1 (no retina), captures, cleans up.
  */
 export async function captureVideo(
   url: string,
   options: VideoOptions,
 ): Promise<VideoResult> {
-  const { getBrowser } = await import('./browser.js');
   const browser = await getBrowser();
 
-  if (hasFfmpeg()) {
-    return captureGifWithVideo(browser, url, options);
+  // For mobile, cap height at 667px for GIF mode
+  const viewport = { ...options.viewport };
+  if (viewport.width <= 430 && viewport.height > MOBILE_GIF_HEIGHT) {
+    viewport.height = MOBILE_GIF_HEIGHT;
   }
 
-  // Default: sequential screenshots
   const page = await browser.newPage({
-    viewport: options.viewport,
-    deviceScaleFactor: 2,
+    viewport,
+    deviceScaleFactor: 1, // DPR 1 — retina wastes pixels in 256-color GIF
   });
 
   try {
-    return await captureGif(page, url, options);
+    return await captureGif(page, url, { ...options, viewport });
   } finally {
     await page.close();
+    await closeDecoderPage();
   }
+}
+
+// ============================================================
+// GIF encoding
+// ============================================================
+
+/**
+ * Encode an array of JPEG screenshot Buffers into an animated GIF.
+ */
+async function encodeGif(
+  browser: Browser,
+  frames: Buffer[],
+  viewport: ViewportSize,
+  fps: number,
+): Promise<Buffer> {
+  const width = viewport.width;
+  const height = viewport.height;
+  const delayCs = Math.round(1000 / fps / 10); // GIF delay is in centiseconds
+
+  const encoder = GIFEncoder();
+
+  for (let i = 0; i < frames.length; i++) {
+    console.log(`Encoding frame ${i + 1}/${frames.length}...`);
+
+    const rgba = await decodeJpegToRgba(browser, frames[i], width, height);
+    const palette = quantize(rgba, 256, { format: 'rgba4444' });
+    const indexed = applyPalette(rgba, palette, 'rgba4444');
+
+    encoder.writeFrame(indexed, width, height, {
+      palette,
+      delay: delayCs,
+      repeat: 0, // loop forever
+    });
+  }
+
+  encoder.finish();
+  return Buffer.from(encoder.bytes());
 }

--- a/src/video.ts
+++ b/src/video.ts
@@ -1,0 +1,406 @@
+/**
+ * Video/GIF capture via sequential Playwright screenshots + gifenc encoding.
+ *
+ * Captures frames at ~100ms intervals (≈10 FPS) and stitches them into
+ * an animated GIF. Designed for short clips (1–5 seconds) of page load
+ * animations, CSS transitions, and layout changes.
+ *
+ * When FFmpeg is available, an alternative path uses Playwright's native
+ * recordVideo (WebM) + FFmpeg palette-optimized conversion for higher quality.
+ */
+
+import { Browser, Page, BrowserContext } from 'playwright';
+import { ViewportSize } from './types.js';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// gifenc ships as CJS bundle — use createRequire for ESM compat
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  GIFEncoder,
+  quantize,
+  applyPalette,
+} = require('gifenc') as {
+  GIFEncoder: (opts?: { initialCapacity?: number }) => GifEncoder;
+  quantize: (data: Uint8Array, maxColors: number, opts?: { format?: string }) => number[][];
+  applyPalette: (data: Uint8Array, palette: number[][], format?: string) => Uint8Array;
+};
+
+interface GifEncoder {
+  writeFrame: (
+    index: Uint8Array,
+    width: number,
+    height: number,
+    opts?: { palette?: number[][]; delay?: number; repeat?: number; dispose?: number },
+  ) => void;
+  finish: () => void;
+  bytes: () => Uint8Array;
+  bytesView: () => Uint8Array;
+}
+
+// ============================================================
+// Public types
+// ============================================================
+
+export interface VideoOptions {
+  /** Viewport size for the capture. */
+  viewport: ViewportSize;
+  /** Recording duration in seconds. Default: 2 */
+  duration?: number;
+  /** Target FPS for GIF output. Default: 8 */
+  fps?: number;
+  /** CSS selector — scroll element into view before recording. */
+  selector?: string;
+  /** Capture full scrollable page. Default: false */
+  fullPage?: boolean;
+  /** Scale factor for GIF output relative to viewport. Default: 0.5 (half-res) */
+  gifScale?: number;
+}
+
+export interface VideoResult {
+  /** Raw GIF data */
+  gif: Buffer;
+  /** Output format identifier */
+  format: 'gif';
+  /** Viewport used for capture */
+  viewport: ViewportSize;
+  /** URL that was captured */
+  url: string;
+  /** Actual recording duration in seconds */
+  duration: number;
+  /** Number of frames in the GIF */
+  frameCount: number;
+  /** CSS selector used, if any */
+  selector?: string;
+}
+
+// ============================================================
+// FFmpeg detection (cached)
+// ============================================================
+
+let ffmpegAvailable: boolean | null = null;
+
+function hasFfmpeg(): boolean {
+  if (ffmpegAvailable !== null) return ffmpegAvailable;
+  try {
+    execSync('which ffmpeg', { stdio: 'pipe' });
+    ffmpegAvailable = true;
+  } catch {
+    ffmpegAvailable = false;
+  }
+  return ffmpegAvailable;
+}
+
+// ============================================================
+// Path B: Sequential screenshots → gifenc (default)
+// ============================================================
+
+/**
+ * Capture a short animated GIF by taking rapid sequential screenshots.
+ *
+ * This is the default path — zero external dependencies beyond Playwright.
+ * Produces ~8 FPS GIFs which is sufficient for most CSS transitions.
+ */
+export async function captureGif(
+  page: Page,
+  url: string,
+  options: VideoOptions,
+): Promise<VideoResult> {
+  const duration = options.duration ?? 2;
+  const fps = options.fps ?? 8;
+  const gifScale = options.gifScale ?? 0.5;
+  const totalFrames = Math.ceil(duration * fps);
+  const frameDelay = Math.round(1000 / fps);
+
+  // Navigate WITHOUT killing animations (unlike screenshot path)
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.evaluate(() => document.fonts.ready);
+
+  // Scroll selector into view if specified
+  if (options.selector) {
+    const locator = page.locator(options.selector);
+    const count = await locator.count();
+    if (count === 0) {
+      throw new Error(`Element not found: ${options.selector}`);
+    }
+    await locator.first().scrollIntoViewIfNeeded();
+    await page.waitForTimeout(100);
+  }
+
+  // Capture frames
+  const frames: Buffer[] = [];
+  for (let i = 0; i < totalFrames; i++) {
+    const screenshot = await page.screenshot({ fullPage: options.fullPage ?? false });
+    frames.push(Buffer.from(screenshot));
+    if (i < totalFrames - 1) {
+      await page.waitForTimeout(frameDelay);
+    }
+  }
+
+  // Encode GIF
+  const gifBuffer = await encodeGif(frames, options.viewport, {
+    fps,
+    scale: gifScale,
+  });
+
+  return {
+    gif: gifBuffer,
+    format: 'gif',
+    viewport: options.viewport,
+    url,
+    duration,
+    frameCount: frames.length,
+    selector: options.selector,
+  };
+}
+
+// ============================================================
+// Path A: Playwright recordVideo + FFmpeg (higher quality)
+// ============================================================
+
+/**
+ * Capture a short animated GIF using Playwright's native video recording
+ * and FFmpeg conversion. Produces smoother output (30+ FPS source).
+ *
+ * Requires FFmpeg installed on the system.
+ */
+export async function captureGifWithVideo(
+  browser: Browser,
+  url: string,
+  options: VideoOptions,
+): Promise<VideoResult> {
+  const duration = options.duration ?? 2;
+  const fps = options.fps ?? 10;
+  const gifScale = options.gifScale ?? 0.5;
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pre-post-video-'));
+
+  const context = await browser.newContext({
+    viewport: options.viewport,
+    deviceScaleFactor: 1, // Record at 1x for video (keeps file size sane)
+    recordVideo: { dir: tmpDir, size: options.viewport },
+  });
+
+  const page = await context.newPage();
+
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await page.evaluate(() => document.fonts.ready);
+
+  if (options.selector) {
+    const locator = page.locator(options.selector);
+    const count = await locator.count();
+    if (count === 0) {
+      await context.close();
+      throw new Error(`Element not found: ${options.selector}`);
+    }
+    await locator.first().scrollIntoViewIfNeeded();
+  }
+
+  // Let animations play
+  await page.waitForTimeout(duration * 1000);
+
+  // Close context to finalize video file
+  const video = page.video();
+  const videoPath = video ? await video.path() : null;
+  await context.close();
+
+  if (!videoPath || !fs.existsSync(videoPath)) {
+    throw new Error('Playwright video recording failed — no output file produced');
+  }
+
+  // Convert WebM → GIF via FFmpeg (two-pass palette optimization)
+  const gifPath = path.join(tmpDir, 'output.gif');
+  const palettePath = path.join(tmpDir, 'palette.png');
+  const gifW = Math.round(options.viewport.width * gifScale);
+
+  try {
+    execSync(
+      `ffmpeg -i "${videoPath}" -vf "fps=${fps},scale=${gifW}:-1:flags=lanczos,palettegen=stats_mode=diff" -y "${palettePath}"`,
+      { stdio: 'pipe', timeout: 15000 },
+    );
+    execSync(
+      `ffmpeg -i "${videoPath}" -i "${palettePath}" -lavfi "fps=${fps},scale=${gifW}:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=bayer:bayer_scale=5" -y "${gifPath}"`,
+      { stdio: 'pipe', timeout: 15000 },
+    );
+
+    const gifBuffer = fs.readFileSync(gifPath);
+
+    return {
+      gif: Buffer.from(gifBuffer),
+      format: 'gif',
+      viewport: options.viewport,
+      url,
+      duration,
+      frameCount: Math.ceil(duration * fps),
+      selector: options.selector,
+    };
+  } finally {
+    // Clean up temp files
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+// ============================================================
+// GIF encoding (pure JS via gifenc)
+// ============================================================
+
+interface EncodeOptions {
+  fps: number;
+  scale: number;
+}
+
+/**
+ * Encode an array of PNG screenshot Buffers into an animated GIF.
+ * Uses gifenc for quantization and LZW encoding.
+ */
+async function encodeGif(
+  frames: Buffer[],
+  viewport: ViewportSize,
+  options: EncodeOptions,
+): Promise<Buffer> {
+  // We need to decode PNG frames to raw RGBA pixels.
+  // Use a canvas-free approach: Playwright screenshots are PNG,
+  // we can use the sharp-free method of creating an offscreen page.
+  // But simpler: just use the raw pixel data from Playwright's screenshot API.
+  //
+  // Actually, Playwright returns PNG-encoded buffers. We need raw RGBA data.
+  // The simplest approach without adding sharp: decode PNG manually.
+  // We'll use a minimal PNG decoder.
+
+  const gifWidth = Math.round(viewport.width * options.scale);
+  const gifHeight = Math.round(viewport.height * options.scale);
+  const delay = Math.round(1000 / options.fps / 10); // GIF delay is in centiseconds
+
+  const encoder = GIFEncoder();
+
+  for (let i = 0; i < frames.length; i++) {
+    // Decode PNG to raw RGBA using built-in approach
+    const rgba = await decodePngToRgba(frames[i], gifWidth, gifHeight);
+
+    // Quantize to 256-color palette
+    const palette = quantize(rgba, 256, { format: 'rgba4444' });
+    const indexed = applyPalette(rgba, palette, 'rgba4444');
+
+    encoder.writeFrame(indexed, gifWidth, gifHeight, {
+      palette,
+      delay,
+      repeat: 0, // loop forever
+      dispose: i === 0 ? -1 : 0,
+    });
+  }
+
+  encoder.finish();
+  return Buffer.from(encoder.bytes());
+}
+
+/**
+ * Decode a PNG buffer to raw RGBA pixel data at a target resolution.
+ *
+ * Uses Playwright's page.evaluate to leverage the browser's built-in
+ * PNG decoder + canvas scaling. This avoids adding sharp/canvas as a dep.
+ *
+ * Falls back to a simple approach using the existing Playwright page.
+ */
+let decoderPage: Page | null = null;
+let decoderBrowser: Browser | null = null;
+
+async function getDecoderPage(browser: Browser): Promise<Page> {
+  if (decoderPage && !decoderPage.isClosed()) return decoderPage;
+  decoderBrowser = browser;
+  decoderPage = await browser.newPage();
+  await decoderPage.setContent('<canvas id="c"></canvas>');
+  return decoderPage;
+}
+
+/**
+ * Minimal PNG decoder — decodes PNG to raw RGBA at target dimensions.
+ * Leverages the browser's native image decoding via a hidden canvas.
+ */
+async function decodePngToRgba(
+  pngBuffer: Buffer,
+  targetWidth: number,
+  targetHeight: number,
+): Promise<Uint8Array> {
+  // We'll use a simple inline approach: convert PNG to data URL,
+  // then use OffscreenCanvas or Canvas to decode and resize.
+  // This works because we already have a Playwright browser running.
+
+  // For now, use the simpler approach of importing the PNG as raw pixels
+  // via a data URL in the browser context.
+
+  // Get a page from the module-level browser
+  const { getBrowser } = await import('./browser.js');
+  const browser = await getBrowser();
+  const pg = await getDecoderPage(browser);
+
+  const base64 = pngBuffer.toString('base64');
+
+  const rawPixels = await pg.evaluate(
+    async ({ b64, w, h }: { b64: string; w: number; h: number }) => {
+      const img = new Image();
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = reject;
+        img.src = `data:image/png;base64,${b64}`;
+      });
+
+      const canvas = document.getElementById('c') as HTMLCanvasElement;
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(img, 0, 0, w, h);
+      const imageData = ctx.getImageData(0, 0, w, h);
+      return Array.from(imageData.data);
+    },
+    { b64: base64, w: targetWidth, h: targetHeight },
+  );
+
+  return new Uint8Array(rawPixels);
+}
+
+/**
+ * Close the decoder page used for PNG→RGBA conversion.
+ * Should be called during cleanup.
+ */
+export async function closeDecoderPage(): Promise<void> {
+  if (decoderPage && !decoderPage.isClosed()) {
+    await decoderPage.close();
+    decoderPage = null;
+  }
+}
+
+// ============================================================
+// Main entry point — auto-selects best available path
+// ============================================================
+
+/**
+ * Capture a short animated GIF of a URL.
+ * Automatically selects the best recording method:
+ * - FFmpeg path (higher quality) when FFmpeg is available
+ * - Sequential screenshot path (zero deps) as default
+ */
+export async function captureVideo(
+  url: string,
+  options: VideoOptions,
+): Promise<VideoResult> {
+  const { getBrowser } = await import('./browser.js');
+  const browser = await getBrowser();
+
+  if (hasFfmpeg()) {
+    return captureGifWithVideo(browser, url, options);
+  }
+
+  // Default: sequential screenshots
+  const page = await browser.newPage({
+    viewport: options.viewport,
+    deviceScaleFactor: 2,
+  });
+
+  try {
+    return await captureGif(page, url, options);
+  } finally {
+    await page.close();
+  }
+}

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -79,6 +79,45 @@ describe('CLI', () => {
       expect(exitCode).not.toBe(0);
       expect(stderr).toContain('Two arguments required');
     });
+
+    it('rejects malformed --duration in video mode', () => {
+      const { stderr, exitCode } = runCli([
+        'compare',
+        '--video',
+        '--duration', '2s',
+        '--before-base', 'https://example.com',
+        '--after-base', 'https://example.com',
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Invalid value for --duration');
+    });
+
+    it('rejects malformed --fps in video mode', () => {
+      const { stderr, exitCode } = runCli([
+        'compare',
+        '--video',
+        '--fps', '5fps',
+        '--before-base', 'https://example.com',
+        '--after-base', 'https://example.com',
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Invalid value for --fps');
+    });
+
+    it('rejects malformed --delay in video mode', () => {
+      const { stderr, exitCode } = runCli([
+        'compare',
+        '--video',
+        '--delay', '250ms',
+        '--before-base', 'https://example.com',
+        '--after-base', 'https://example.com',
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain('Invalid value for --delay');
+    });
   });
 
   describe('detect subcommand', () => {


### PR DESCRIPTION
## Summary

This PR adds support for capturing animated GIFs of web pages instead of static screenshots. Users can now use the `--video` flag to record page-load animations, CSS transitions, and layout changes as GIFs that render inline in GitHub PR comments.

## Key Changes

- **New `captureVideo()` and `captureGif()` functions** (`src/video.ts`): Core GIF capture pipeline that takes sequential JPEG screenshots via Playwright and encodes them into animated GIFs using gifenc. Includes:
  - JPEG-to-RGBA decoding via hidden canvas page (no external image library dependencies)
  - 256-color palette quantization and frame encoding
  - Early-stop detection when animation settles (3+ identical frames)
  - Mobile viewport height capping at 667px for GIF mode (above-the-fold)

- **CLI flag additions** (`src/bin/cli.ts`):
  - `--video`: Enable GIF capture mode
  - `--duration <seconds>`: Recording duration (default: 3s, max: 10s)
  - `--fps <n>`: Target frames per second (default: 5, max: 10)
  - `--delay <ms>`: Wait time after page load before recording (default: 0)
  - Validation: `--video` + `--full` is rejected; duration/fps bounds enforced

- **Integration with existing commands**:
  - `runDefault()`: Captures GIFs for before/after URLs when `--video` is set
  - `runCompare()`: Captures GIFs for each route, works with `--responsive` (desktop + mobile GIFs per route)
  - `runFull()`: Passes `--video` through to `runCompare()`

- **Type definitions** (`src/types.ts`): Added `VideoOptions` and `VideoResult` interfaces for type-safe video capture configuration and results

- **Filename generation** (`src/filename.ts`): Extended `generateFilename()` to support `.gif` extension via new `format` parameter

- **Upload support** (`src/upload.ts`): 
  - Added 10 MB file size limit with actionable error message
  - Updated content-type headers for GIF uploads (Vercel Blob, generic PUT)

- **Browser utilities** (`src/browser.ts`): Exported `getBrowser()` function to allow video.ts to create fresh pages without animation-killing CSS

- **Exports** (`src/index.ts`): Exposed `captureVideo` and `captureGif` for public API

## Implementation Details

- **No external dependencies added** beyond gifenc (already in package.json): Uses Playwright's built-in screenshot capability and canvas-based JPEG decoding
- **DPR fixed at 1**: Retina scaling (DPR 2+) would quadruple pixel count, defeating the purpose of 256-color GIF compression
- **Real-world FPS lower than target**: ~100-200ms per screenshot means 5 FPS target yields ~3-4 FPS actual
- **Decoder page reused**: Single hidden canvas page decodes all JPEG frames, closed in finally block to prevent leaks
- **gifenc CJS compatibility**: Uses `createRequire(import.meta.url)` for ESM module compatibility

## CLI Examples

```bash
pre-post https://old.com https://new.com --video
pre-post https://old.com https://new.com --video --duration 5 --fps 8 --delay 500
pre-post compare --before-base prod.com --after-base localhost:3000 --video --responsive
```

https://claude.ai/code/session_01JoVCfxXkjU5MFAdMYSYSpb