### PR TITLE
Update skill installation instructions and add npm package note

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,13 +249,19 @@ Supports:
 
 ## Add Skill
 
-Install as a Claude Code skill:
+Install as an agent skill using the [`skills` CLI](https://github.com/vercel-labs/skills):
 
 ```bash
-npx skills add juangadm/pre-post
+npx skills add juangadm/pre-post          # interactive — pick your agent(s)
+npx skills add juangadm/pre-post -y       # auto-install to all universal agents
+npx skills add juangadm/pre-post -y -g    # install globally (all projects)
 ```
 
+This copies `skill/SKILL.md` into the appropriate directory for your agent (e.g., `.claude/skills/` for Claude Code, `.agents/skills/` for Amp/Codex/Gemini CLI, etc.).
+
 The skill uses `gh` to detect the associated PR and Playwright for screenshots.
+
+> **Note:** The npm package (`@juangadm/pre-post`) is published on [npmjs.com](https://www.npmjs.com/package/@juangadm/pre-post), not GitHub Packages — so the "Packages" section on the GitHub repo page will show none.
 
 ## Credits
 


### PR DESCRIPTION
## Summary
Updated the "Add Skill" section in README.md to provide clearer and more comprehensive installation instructions for the skill across different agent platforms.

## Key Changes
- Replaced generic "Install as a Claude Code skill" with agent-agnostic "Install as an agent skill" language
- Added reference to the [`skills` CLI](https://github.com/vercel-labs/skills) tool
- Expanded installation examples to show three common use cases:
  - Interactive installation (pick specific agents)
  - Auto-install to all universal agents (`-y` flag)
  - Global installation across all projects (`-y -g` flags)
- Added explanation of where the skill gets copied to for different agents (`.claude/skills/`, `.agents/skills/`, etc.)
- Added note clarifying that the npm package is published on npmjs.com, not GitHub Packages

## Notable Details
- The changes make the documentation more inclusive of multiple agent platforms (Claude Code, Amp, Codex, Gemini CLI)
- Provides users with clear options for different installation scenarios
- Addresses potential confusion about package location by explicitly noting npmjs.com publication

https://claude.ai/code/session_01UfNpzmVBymmjLBJMQV3ZfD